### PR TITLE
Multi-color

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "colorize-macros"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 description = "A set of Rust macros to assist in turning text into colors for printing on the terminal."
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ name = "colorize"
 path = "src/lib.rs"
 
 [dependencies]
+paste = "1.0.14"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ See the [colorize macro](https://docs.rs/colorize-macros/latest/colorize/macro.c
 ## Development
 - [x] Add background color
 - [ ] Rework the `colorize!` macro or create a new macro so it acts more like `format!`
-- [ ] Add ability to format multiple arguments with the same input (ie `colorize!(b => "Hello", Fg-> "world")` where "Hello" and "world" are both bold but "world" is the only word that's green)
+- [x] Add ability to format multiple arguments with the same input (ie `colorize!(b => "Hello", Fg-> "world")` where "Hello" and "world" are both bold but "world" is the only word that's green)
 - [ ] Integrate a color set of log macros from the [log](https://docs.rs/log/latest/log/) crate
 
 ## Special Thanks

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! A set of Rust macros to assist in turning text into colors for printing on the terminal.
 //!
-//! ```ignore
+//! ```
+//! # use colorize::_colorize;
 //! use colorize::{colorize, print_color};
 //!
 //! // Convert text into a String with colors
@@ -81,6 +82,8 @@ pub fn color_str<T: std::fmt::Debug>(input: T, tag: &str) -> String {
     format!("{}\x1b[{}m{}\x1b[0m", newline, attr.join(";"), input)
 }
 
+#[doc(hidden)]
+#[macro_export]
 macro_rules! _colorize {
 
     () => {String::new()};
@@ -158,7 +161,8 @@ macro_rules! _colorize {
 /// **Adding the actual `\n` character will cause issues, use the token!!**
 ///
 /// Example -
-/// ```ignore
+/// ```
+/// # use colorize::_colorize;
 /// use colorize::colorize;
 ///
 /// let color_string = colorize!(
@@ -167,8 +171,21 @@ macro_rules! _colorize {
 /// );
 /// ```
 ///
+/// #### Fomrat Multiple Inputs
+/// You also have the ability to apply a token to multiple inputs by using `=>` at the beginning of the call.
+///
+/// ```
+/// # use colorize::_colorize;
+/// # use paste::paste;
+/// use colorize::colorize;
+///
+/// let color_string = colorize!(b => Fg->"Hello", By->"world");
+/// ```
+/// In the above example, "Hello" will have a green foreground, and "world" will have a yellow background. The preceeding `b =>` applies bold formatting to both.
+///
 /// ### Examples
-/// ```ignore
+/// ```
+/// # use colorize::_colorize;
 /// use colorize::colorize;
 ///
 /// // Returns "Hello" in bold green
@@ -182,7 +199,7 @@ macro_rules! _colorize {
 /// ```
 #[macro_export]
 macro_rules! colorize {
-    ( $($any:tt)* ) => { _colorize!([]; $($any)*, ) };
+    ( $($any:tt)* ) => { $crate::_colorize!([]; $($any)*, ) };
 }
 
 /// `println!` using the [`colorize!`] macro
@@ -191,8 +208,9 @@ macro_rules! colorize {
 /// See [`colorize!`] for more details
 ///
 /// ## Usage
-/// ```ignore
-/// use colorize::*;
+/// ```
+/// # use colorize::{colorize, _colorize};
+/// use colorize::print_color;
 ///
 /// // Will println to the console with "Hello" bold and green, world will be unformatted
 /// print_color!(Fgb->"Hello", "world")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,9 @@
 //! #### Special Thanks
 //! This crate was originally inspired by the [row](https://github.com/phsym/prettytable-rs/blob/master/src/row.rs) macro in [prettytable](https://github.com/phsym/prettytable-rs).
 
+#[allow(unused)]
+use paste::paste;
+
 /// Helper function called by [`colorize!`] to convert tokens/string to color text
 ///
 /// This function is not strictly needed for usage of this crate, but is made available in case.
@@ -92,7 +95,7 @@ macro_rules! _colorize {
     ( [ $($acc:tt)* ]; $msg:expr, $($rest:tt)* ) => {_colorize!([$($acc)* $msg.to_string() ,]; $($rest)*)};
 
     ( [ $($acc:tt)* ]; $tag:ident => $id:ident -> $msg:expr, $($rest:tt)*) => {
-        paste::paste!{
+        paste!{
             {
                 let color = $crate::color_str( $msg, stringify!([<$tag $id>]));
                 _colorize!(


### PR DESCRIPTION
# Changes

- Added new functionality which allows the user to apply a format to multiple inputs instead of having to write out each one individually
- Refactored `colorize`
   - Moved logic to a private api to minimize recursion related errors
   - Changed logic handling for trailing commas to avoid an error in this event